### PR TITLE
Created statistic controller for optimizing api-calling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     // Utilities
     implementation("one.stayfocused.spring:dotenv-spring-boot:1.0.0")
     implementation("javax.annotation:javax.annotation-api:1.3.2")
+    implementation("org.aspectj:aspectjweaver")
 
     // Tests
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/org/careerseekers/cseventsservice/annotations/DirectionDocsUpdate.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/annotations/DirectionDocsUpdate.kt
@@ -1,0 +1,5 @@
+package org.careerseekers.cseventsservice.annotations
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DirectionDocsUpdate()

--- a/src/main/kotlin/org/careerseekers/cseventsservice/annotations/DirectionsUpdate.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/annotations/DirectionsUpdate.kt
@@ -1,0 +1,5 @@
+package org.careerseekers.cseventsservice.annotations
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DirectionsUpdate()

--- a/src/main/kotlin/org/careerseekers/cseventsservice/annotations/PlatformsUpdate.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/annotations/PlatformsUpdate.kt
@@ -1,0 +1,5 @@
+package org.careerseekers.cseventsservice.annotations
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PlatformsUpdate()

--- a/src/main/kotlin/org/careerseekers/cseventsservice/aspects/DirectionDocsUpdatesAspect.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/aspects/DirectionDocsUpdatesAspect.kt
@@ -1,0 +1,26 @@
+package org.careerseekers.cseventsservice.aspects
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.careerseekers.cseventsservice.aspects.interfaces.IEntityUpdatesAspect
+import org.careerseekers.cseventsservice.utils.StatisticsScrapperService
+import org.careerseekers.cseventsservice.utils.StatisticsStorage
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class DirectionDocsUpdatesAspect(private val statisticsScrapperService: StatisticsScrapperService) :
+    IEntityUpdatesAspect {
+
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+
+    @AfterReturning("@annotation(org.careerseekers.cseventsservice.annotations.DirectionDocsUpdate)")
+    override fun afterUpdate(joinPoint: JoinPoint) {
+        statisticsScrapperService.setDirectionDocsCount()
+        statisticsScrapperService.setLastDocumentUpload()
+
+        logger.info("Directions documents count updated, the caller method is ${joinPoint.signature.name}. Total documents: ${StatisticsStorage.directionDocsCount}, last document upload: ${StatisticsStorage.lastDocumentUpload}.")
+    }
+}

--- a/src/main/kotlin/org/careerseekers/cseventsservice/aspects/DirectionsUpdatesAspect.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/aspects/DirectionsUpdatesAspect.kt
@@ -1,0 +1,25 @@
+package org.careerseekers.cseventsservice.aspects
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.careerseekers.cseventsservice.aspects.interfaces.IEntityUpdatesAspect
+import org.careerseekers.cseventsservice.utils.StatisticsScrapperService
+import org.careerseekers.cseventsservice.utils.StatisticsStorage
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class DirectionsUpdatesAspect(private val statisticsScrapperService: StatisticsScrapperService) : IEntityUpdatesAspect {
+
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+
+    @AfterReturning("@annotation(org.careerseekers.cseventsservice.annotations.DirectionsUpdate)")
+    override fun afterUpdate(joinPoint: JoinPoint) {
+        statisticsScrapperService.setDirectionsCount()
+        statisticsScrapperService.setDirectionsWithoutDocs()
+
+        logger.info("Directions count updated, the caller method is ${joinPoint.signature.name}. Total directions: ${StatisticsStorage.directionsCount}, direction without docs: ${StatisticsStorage.directionsWithoutDocs}")
+    }
+}

--- a/src/main/kotlin/org/careerseekers/cseventsservice/aspects/PlatformUpdatesAspect.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/aspects/PlatformUpdatesAspect.kt
@@ -1,0 +1,24 @@
+package org.careerseekers.cseventsservice.aspects
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.careerseekers.cseventsservice.aspects.interfaces.IEntityUpdatesAspect
+import org.careerseekers.cseventsservice.utils.StatisticsScrapperService
+import org.careerseekers.cseventsservice.utils.StatisticsStorage
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class PlatformUpdatesAspect(private val statisticsScrapperService: StatisticsScrapperService) : IEntityUpdatesAspect {
+
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+
+    @AfterReturning("@annotation(org.careerseekers.cseventsservice.annotations.PlatformsUpdate)")
+    override fun afterUpdate(joinPoint: JoinPoint) {
+        statisticsScrapperService.setPlatformsCount()
+
+        logger.info("Platforms count updated, the caller method is ${joinPoint.signature.name}. Total platforms: ${StatisticsStorage.platformsCount}.")
+    }
+}

--- a/src/main/kotlin/org/careerseekers/cseventsservice/aspects/interfaces/IEntityUpdatesAspect.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/aspects/interfaces/IEntityUpdatesAspect.kt
@@ -1,0 +1,7 @@
+package org.careerseekers.cseventsservice.aspects.interfaces
+
+import org.aspectj.lang.JoinPoint
+
+interface IEntityUpdatesAspect {
+    fun afterUpdate(joinPoint: JoinPoint)
+}

--- a/src/main/kotlin/org/careerseekers/cseventsservice/services/DirectionDocumentsService.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/services/DirectionDocumentsService.kt
@@ -1,5 +1,6 @@
 package org.careerseekers.cseventsservice.services
 
+import org.careerseekers.cseventsservice.annotations.DirectionDocsUpdate
 import org.careerseekers.cseventsservice.dto.docs.CreateDirectionDocumentDto
 import org.careerseekers.cseventsservice.dto.docs.UpdateDirectionDocumentDto
 import org.careerseekers.cseventsservice.entities.DirectionDocuments
@@ -31,6 +32,7 @@ class DirectionDocumentsService(
 
     fun getByDirectionId(id: Long) = repository.findByDirectionId(id)
 
+    @DirectionDocsUpdate
     @Transactional
     override fun create(item: CreateDirectionDocumentDto): DirectionDocuments {
         val direction =
@@ -83,6 +85,7 @@ class DirectionDocumentsService(
         } ?: throw NotFoundException("Документ компетенции с ID $id не найден.")
     }
 
+    @DirectionDocsUpdate
     @Transactional
     override fun deleteById(id: Long): String {
         getById(id, message = "Документ с ID '${id}' не найден.")!!.apply(repository::delete)
@@ -90,6 +93,7 @@ class DirectionDocumentsService(
         return "Документ удален успешно."
     }
 
+    @DirectionDocsUpdate
     @Transactional
     override fun deleteAll(): String {
         repository.deleteAll()

--- a/src/main/kotlin/org/careerseekers/cseventsservice/services/DirectionsService.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/services/DirectionsService.kt
@@ -1,5 +1,6 @@
 package org.careerseekers.cseventsservice.services
 
+import org.careerseekers.cseventsservice.annotations.DirectionsUpdate
 import org.careerseekers.cseventsservice.cache.UsersCacheClient
 import org.careerseekers.cseventsservice.dto.DirectionCreation
 import org.careerseekers.cseventsservice.dto.directions.CreateDirectionDto
@@ -39,6 +40,7 @@ class DirectionsService(
     fun getByAgeCategory(ageCategory: DirectionAgeCategory): List<Directions> =
         repository.findByAgeCategory(ageCategory)
 
+    @DirectionsUpdate
     @Transactional
     override fun create(item: CreateDirectionDto): Directions {
         val tutor = item.userId?.let {
@@ -79,6 +81,7 @@ class DirectionsService(
         }
     }
 
+    @DirectionsUpdate
     @Transactional
     override fun createAll(items: List<CreateDirectionDto>): String {
         for (item in items) {
@@ -172,6 +175,7 @@ class DirectionsService(
         if (modifiedChildren.isNotEmpty()) childToDirectionRepository.saveAll(modifiedChildren)
     }
 
+    @DirectionsUpdate
     @Transactional
     override fun deleteById(id: Long): String {
         getById(id, message = "Компетенция с ID '${id}' не найдена.")!!.run {
@@ -182,6 +186,7 @@ class DirectionsService(
         }
     }
 
+    @DirectionsUpdate
     @Transactional
     override fun deleteAll(): String {
         getAll().forEach { direction ->

--- a/src/main/kotlin/org/careerseekers/cseventsservice/services/PlatformsService.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/services/PlatformsService.kt
@@ -1,5 +1,6 @@
 package org.careerseekers.cseventsservice.services
 
+import org.careerseekers.cseventsservice.annotations.PlatformsUpdate
 import org.careerseekers.cseventsservice.cache.UsersCacheClient
 import org.careerseekers.cseventsservice.dto.PlatformCreation
 import org.careerseekers.cseventsservice.dto.platforms.ChangePlatformOwnerDto
@@ -30,6 +31,7 @@ class PlatformsService(
         return repository.findByUserId(userId) ?: throw NotFoundException("Площадка с userID $userId не найдена.")
     }
 
+    @PlatformsUpdate
     @Transactional
     override fun create(item: CreatePlatformDto): Platforms {
         return usersCacheClient.getItemFromCache(item.userId)?.let {
@@ -96,6 +98,7 @@ class PlatformsService(
         return "Платформа верифицирована успешно."
     }
 
+    @PlatformsUpdate
     @Transactional
     override fun deleteById(id: Long): String {
         getById(id, message = "Платформа с ID $id не найдена.")?.let {

--- a/src/main/kotlin/org/careerseekers/cseventsservice/utils/StatisticsScrapperService.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/utils/StatisticsScrapperService.kt
@@ -1,0 +1,47 @@
+package org.careerseekers.cseventsservice.utils
+
+import org.careerseekers.cseventsservice.services.DirectionDocumentsService
+import org.careerseekers.cseventsservice.services.DirectionsService
+import org.careerseekers.cseventsservice.services.PlatformsService
+import org.springframework.beans.factory.SmartInitializingSingleton
+
+@Utility
+class StatisticsScrapperService(
+    private val platformsService: PlatformsService,
+    private val directionsService: DirectionsService,
+    private val directionDocumentsService: DirectionDocumentsService
+) : SmartInitializingSingleton {
+
+    override fun afterSingletonsInstantiated() {
+        setPlatformsCount()
+        setDirectionsCount()
+        setDirectionsWithoutDocs()
+        setDirectionDocsCount()
+        setLastDocumentUpload()
+    }
+
+
+    fun setPlatformsCount() {
+        val platforms = platformsService.getAll()
+
+        StatisticsStorage.setPlatformsCount(platforms.size.toLong())
+        StatisticsStorage.setVerifiedPlatformsCount(platforms.filter { it.verified }.size.toLong())
+    }
+
+    fun setDirectionsCount() = StatisticsStorage.setDirectionsCount(directionsService.getAll().size.toLong())
+
+    fun setDirectionsWithoutDocs() = StatisticsStorage.setDirectionsWithoutDocs(
+        directionsService.getAll().filter { it.documents == null }.size.toLong()
+    )
+
+    fun setDirectionDocsCount() =
+        StatisticsStorage.setDirectionDocsCount(directionDocumentsService.getAll().size.toLong())
+
+    fun setLastDocumentUpload() = StatisticsStorage.setLastDocumentUpload(
+        directionDocumentsService
+            .getAll()
+            .sortedByDescending { it.createdAt }
+            .firstOrNull()
+            ?.createdAt
+    )
+}

--- a/src/main/kotlin/org/careerseekers/cseventsservice/utils/StatisticsStorage.kt
+++ b/src/main/kotlin/org/careerseekers/cseventsservice/utils/StatisticsStorage.kt
@@ -1,0 +1,32 @@
+package org.careerseekers.cseventsservice.utils
+
+import java.time.LocalDateTime
+
+object StatisticsStorage {
+    var platformsCount: Long = 0
+        private set
+
+    var verifiedPlatformsCount: Long = 0
+        private set
+
+    var directionsCount: Long = 0
+        private set
+
+    var directionsWithoutDocs: Long = 0
+        private set
+
+    var directionDocsCount: Long = 0
+        private set
+
+    var lastDocumentUpload: LocalDateTime? = null
+        private set
+
+    fun setPlatformsCount(platformsCount: Long) = apply { this.platformsCount = platformsCount }
+    fun setVerifiedPlatformsCount(platformsCount: Long) = apply { this.verifiedPlatformsCount = platformsCount }
+
+    fun setDirectionsCount(count: Long) = apply { this.directionsCount = count }
+    fun setDirectionsWithoutDocs(count: Long) = apply { this.directionsWithoutDocs = count }
+
+    fun setDirectionDocsCount(count: Long) = apply { this.directionDocsCount = count }
+    fun setLastDocumentUpload(lastDocumentUpload: LocalDateTime?) = apply { this.lastDocumentUpload = lastDocumentUpload }
+}


### PR DESCRIPTION
Closes #54 

This pull request introduces a new aspect-oriented mechanism for updating statistics related to directions, direction documents, and platforms. It adds custom annotations and aspects to automatically update and log relevant statistics after certain service operations. The changes also include the implementation of a centralized statistics scrapper and storage utility to keep track of various counts and timestamps.

### Aspect-Oriented Statistics Updates

* Added custom annotations (`DirectionDocsUpdate`, `DirectionsUpdate`, `PlatformsUpdate`) to mark service methods that should trigger statistics updates. [[1]](diffhunk://#diff-c1447d22ccc2d077a70e718582c9705efaf93b4ffd24f205f95a7e87f439fa81R1-R5) [[2]](diffhunk://#diff-1528281a44cf8c716f2fdb75773ee3b76a5320f550171c73b7d19005bdd57768R1-R5) [[3]](diffhunk://#diff-ed27f040ac82011ff2f8614c30501f98b672a2a188a692ff038277037646ae1aR1-R5)
* Implemented aspect classes (`DirectionDocsUpdatesAspect`, `DirectionsUpdatesAspect`, `PlatformUpdatesAspect`) that intercept annotated service methods and update statistics using `StatisticsScrapperService`. These aspects also log the updated statistics. [[1]](diffhunk://#diff-9b495a60b2b112dbf0c3817d30aa723c7e5223e9813cfb9ae9b8a1ac8272fd13R1-R26) [[2]](diffhunk://#diff-0e4d2861b883d42c35e0d9b0020b30e6f8d8f5c76f2020bbd5677e41212f82b5R1-R25) [[3]](diffhunk://#diff-7045b0a8682aeb039bbb7a0c78b56447b9030270015d7ceb41735d5f1355f4d1R1-R24)
* Introduced a common interface `IEntityUpdatesAspect` for these aspects to standardize the after-update hook.

### Service Layer Integration

* Annotated relevant CRUD methods in `DirectionsService`, `DirectionDocumentsService`, and `PlatformsService` with the new update annotations to trigger statistics updates automatically. [[1]](diffhunk://#diff-e49d7df5026aaf3c1cdf3a35b96eafbbfcfd4b55ae2b6f728765e506d8fbf795R3) [[2]](diffhunk://#diff-e49d7df5026aaf3c1cdf3a35b96eafbbfcfd4b55ae2b6f728765e506d8fbf795R35) [[3]](diffhunk://#diff-e49d7df5026aaf3c1cdf3a35b96eafbbfcfd4b55ae2b6f728765e506d8fbf795R88-R96) [[4]](diffhunk://#diff-c26ab99c8374726a490ae5b92d24a8bfea723da73aaee1da2cb98d22e1a534a3R3) [[5]](diffhunk://#diff-c26ab99c8374726a490ae5b92d24a8bfea723da73aaee1da2cb98d22e1a534a3R43) [[6]](diffhunk://#diff-c26ab99c8374726a490ae5b92d24a8bfea723da73aaee1da2cb98d22e1a534a3R84) [[7]](diffhunk://#diff-c26ab99c8374726a490ae5b92d24a8bfea723da73aaee1da2cb98d22e1a534a3R178) [[8]](diffhunk://#diff-c26ab99c8374726a490ae5b92d24a8bfea723da73aaee1da2cb98d22e1a534a3R189) [[9]](diffhunk://#diff-44b286000ba17af9b211e95d248683928d4d0ee0c19760f87d1c83669c3f1e54R3) [[10]](diffhunk://#diff-44b286000ba17af9b211e95d248683928d4d0ee0c19760f87d1c83669c3f1e54R34) [[11]](diffhunk://#diff-44b286000ba17af9b211e95d248683928d4d0ee0c19760f87d1c83669c3f1e54R101)

### Centralized Statistics Management

* Added `StatisticsScrapperService`, a utility class responsible for updating various statistics by querying the services. It runs initial statistics computation after bean initialization and provides methods for updating specific statistics.
* Created `StatisticsStorage`, a singleton object to store and expose statistics such as counts and the last document upload timestamp, with controlled setters.